### PR TITLE
Fix schema command

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,10 @@ steps:
   displayName: 'Cross Compile'
 
 - script: |
+    make test-integration
+  displayName: 'Integration Test'
+
+- script: |
     AZURE_STORAGE_CONNECTION_STRING=$(AZURE_STORAGE_CONNECTION_STRING) make publish
   displayName: 'Publish'
   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))

--- a/tests/schema_integration_test.go
+++ b/tests/schema_integration_test.go
@@ -1,0 +1,36 @@
+// +build integration
+
+package tests
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Add a test that checked that the schema was packed into the binary
+// properly. Requires a make clean xbuild-all first.
+func TestSchema(t *testing.T) {
+	schemaBackup := "../pkg/docker/schema/schema.json.bak"
+	schemaPath := "../pkg/docker/schema/schema.json"
+
+	defer os.Rename(schemaBackup, schemaPath)
+	err := os.Rename(schemaPath, schemaBackup)
+	require.NoError(t, err, "failed to sabotage the schema.json")
+
+	output := &bytes.Buffer{}
+	cmd := exec.Command("docker", "schema")
+	cmd.Path = "../bin/mixins/docker/docker"
+	cmd.Stdout = output
+	cmd.Stderr = output
+
+	err = cmd.Start()
+	require.NoError(t, err, "failed to start the docker schema command")
+
+	err = cmd.Wait()
+	t.Log(output)
+	require.NoError(t, err, "docker schema failed")
+}


### PR DESCRIPTION
* We weren't running generate so the binaries that we shipped didn't include the schema.json file in the binary.
* Add a regression test to catch this type of bug from shipping again.
* Make some tweaks to match our solution for schema with the standard.