### PR TITLE
Fix schema integration test

### DIFF
--- a/tests/schema_integration_test.go
+++ b/tests/schema_integration_test.go
@@ -22,8 +22,7 @@ func TestSchema(t *testing.T) {
 	require.NoError(t, err, "failed to sabotage the schema.json")
 
 	output := &bytes.Buffer{}
-	cmd := exec.Command("docker", "schema")
-	cmd.Path = "../bin/mixins/docker/docker"
+	cmd := exec.Command("../bin/mixins/docker/docker", "schema")
 	cmd.Stdout = output
 	cmd.Stderr = output
 


### PR DESCRIPTION
I was setting the path after the command constructor but the constructor checks if the path to the command exists and sets a flag to fail on Start when it cannot be found. So in this case if docker isn't in your path, it will fail even though I set the full path to the docker mixin on the next line.

The proper way to use exec.Command is to set the full path to the command to call in the constructor and it cannot be changed later.