### PR TITLE
add suppress output option for run to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ You can specify either the tag or the digest.
         REPEATED_FLAG:
         - FLAGVALUE1
         - FLAGVALUE2
+      suppress-output: BOOL #defaults to false
 ```
 
 #### Example


### PR DESCRIPTION
Run has a new option to suppress output in v0.2.0, so adding that to the syntax in the readme.