### PR TITLE
Remove unnecessary dockerfile lines

### DIFF
--- a/pkg/docker/build.go
+++ b/pkg/docker/build.go
@@ -9,19 +9,13 @@ import (
 
 // This is an example. Replace the following with whatever steps are needed to
 // install required components into
-const dockerfileLines = `FROM debian:stretch
-
-ARG BUNDLE_DIR
-RUN apt-get update && apt-get install -y curl ca-certificates
-
-ARG DOCKER_VERSION=%s
-RUN curl -o docker.tgz https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz && \
+const dockerfileLines = `ARG DOCKER_VERSION=%s
+RUN apt-get update && apt-get install -y curl && \
+	curl -o docker.tgz https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz && \
     tar -xvf docker.tgz && \
     mv docker/docker /usr/bin/docker && \
     chmod +x /usr/bin/docker && \
     rm docker.tgz
-
-COPY . $BUNDLE_DIR
 `
 
 // BuildInput represents stdin passed to the mixin for the build command.

--- a/pkg/docker/build_test.go
+++ b/pkg/docker/build_test.go
@@ -10,28 +10,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const buildOutputTemplate = `FROM debian:stretch
-
-ARG BUNDLE_DIR
-RUN apt-get update && apt-get install -y curl ca-certificates
-
-ARG DOCKER_VERSION=%s
-RUN curl -o docker.tgz https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz && \
-    tar -xvf docker.tgz && \
-    mv docker/docker /usr/bin/docker && \
-    chmod +x /usr/bin/docker && \
-    rm docker.tgz
-
-COPY . $BUNDLE_DIR
-`
-
 func TestMixin_Build(t *testing.T) {
 	t.Run("build with the default Docker version", func(t *testing.T) {
 		m := NewTestMixin(t)
 		err := m.Build()
 		require.NoError(t, err)
 
-		wantOutput := fmt.Sprintf(buildOutputTemplate, "19.03.8")
+		wantOutput := fmt.Sprintf(dockerfileLines, "19.03.8")
 
 		gotOutput := m.TestContext.GetOutput()
 		assert.Equal(t, wantOutput, gotOutput)
@@ -46,7 +31,7 @@ func TestMixin_Build(t *testing.T) {
 		err = m.Build()
 		require.NoError(t, err)
 
-		wantOutput := fmt.Sprintf(buildOutputTemplate, "19.03.12")
+		wantOutput := fmt.Sprintf(dockerfileLines, "19.03.12")
 
 		gotOutput := m.TestContext.GetOutput()
 		assert.Equal(t, wantOutput, gotOutput)


### PR DESCRIPTION
Do not include dockerfile lines that the user would include in their template. Only define the lines required to install the mixin.

Fixes #24 